### PR TITLE
Support searches built from the front page advanced search form, including date ranges

### DIFF
--- a/app/archivesspace-public/app/controllers/concerns/searchable.rb
+++ b/app/archivesspace-public/app/controllers/concerns/searchable.rb
@@ -57,6 +57,68 @@ module Searchable
     @criteria['page_size'] = params.fetch(:page_size, AppConfig[:search_results_page_size])
   end
 
+
+  def set_up_advanced_search(default_types = [],default_facets=[],default_search_opts={}, params={})
+    limit = params.fetch(:limit,'')
+    if !limit.blank?
+      default_types = [limit]
+    end
+
+    queries = params.fetch(:q, nil)
+
+    raise "No query?" if queries.nil?
+
+    ops = params.fetch(:op, [])
+    fields = params.fetch(:field, [])
+    from_years = params.fetch(:from_year, [])
+    to_years = params.fetch(:to_year, [])
+
+    advanced_query_builder = AdvancedQueryBuilder.new
+
+    queries.each_with_index { |query, i|
+      op = ops[i]
+      field = fields[i].blank? ? 'keyword' : fields[i]
+      from = from_years[i]
+      to = to_years[i]
+
+      @base_search += '&' if @base_search.last != '?'
+      @base_search += "q[]=#{CGI.escape(query)}&op[]=#{CGI.escape(op)}&field[]=#{CGI.escape(field)}&from_year[]=#{CGI.escape(from)}&to_year[]=#{CGI.escape(to)}"
+
+      builder = AdvancedQueryBuilder.new
+
+      # add field part of the row
+      builder.and(field, query, 'text', op == 'NOT')
+
+      # add year range part of the row
+      unless from.blank? && to.blank?
+        builder.and('years', AdvancedQueryBuilder::RangeValue.new(from, to), 'range', op == 'NOT')
+      end
+
+      # add to the builder based on the op
+      if op == 'OR'
+        advanced_query_builder.or(builder)
+      else
+        advanced_query_builder.and(builder)
+      end
+    }
+
+    @criteria = default_search_opts
+
+    @base_search += "limit=#{limit}&" if !limit.blank?
+
+    @facet_filter = FacetFilter.new(default_facets, params.fetch(:filter_fields,[]), params.fetch(:filter_values,[]))
+    # building the query for the facetting
+    type_query_builder = AdvancedQueryBuilder.new
+    default_types.reduce(type_query_builder) {|b, type|
+      b.or('types', type)
+    }
+
+    @criteria['filter'] = advanced_query_builder.and(@facet_filter.get_filter_query.and(type_query_builder)).build.to_json
+    @criteria['facet[]'] = @facet_filter.get_facet_types
+    @criteria['page_size'] = params.fetch(:page_size, AppConfig[:search_results_page_size])
+  end
+
+
   def get_years(params)
     years = {}
     from = params.fetch(:from_year,'').strip

--- a/app/archivesspace-public/app/controllers/search_controller.rb
+++ b/app/archivesspace-public/app/controllers/search_controller.rb
@@ -11,7 +11,7 @@ class SearchController < ApplicationController
 
   def search
     @base_search = "/search?"
-    set_up_search(DEFAULT_TYPES, DEFAULT_SEARCH_FACET_TYPES, DEFAULT_SEARCH_OPTS, params)
+    set_up_advanced_search(DEFAULT_TYPES, DEFAULT_SEARCH_FACET_TYPES, DEFAULT_SEARCH_OPTS, params)
     page = Integer(params.fetch(:page, "1"))
     Rails.logger.debug("base search: #{@base_search}")
     Rails.logger.debug("query: #{@query}")

--- a/app/archivesspace-public/app/lib/app_config.rb
+++ b/app/archivesspace-public/app/lib/app_config.rb
@@ -44,6 +44,8 @@ class AppConfig
   end
 
   def self.reload
+    $CONFIG_DEFAULTS_LOADED = false
+
     @@parameters = {}
 
     AppConfig.load_defaults


### PR DESCRIPTION
Hi @bobbi-SMR,

We've extended the `AdvancedQueryBuilder` to support a range value.  This means we can use it to add "date range" queries, like:

```
builder.and('years', AdvancedQueryBuilder::RangeValue.new(from, to), 'range', op == 'NOT')
```

which is converted by the ArchivesSpace service to something like `(years:[1999 TO *])` if `from = 1999` and `to = nil`.

This has been added to our ArchivesSpace branch 'public-new', so you can start using now.

I've also had a quick go at implementing the multiline search using the AdvancedQueryBuilder.  See `set_up_advanced_search`. This drops the `@query` from the search and builds up an impressive `@criteria['filter']`.

Hopefully it gives you something to work from!

Payten
