### PR TITLE
Patch multiline search changes

### DIFF
--- a/app/archivesspace-public/app/controllers/concerns/searchable.rb
+++ b/app/archivesspace-public/app/controllers/concerns/searchable.rb
@@ -104,7 +104,7 @@ module Searchable
 
     @criteria = default_search_opts
 
-    @base_search += "limit=#{limit}&" if !limit.blank?
+    @base_search += "&limit=#{limit}" if !limit.blank?
 
     @facet_filter = FacetFilter.new(default_facets, params.fetch(:filter_fields,[]), params.fetch(:filter_values,[]))
     # building the query for the facetting
@@ -113,7 +113,8 @@ module Searchable
       b.or('types', type)
     }
 
-    @criteria['filter'] = advanced_query_builder.and(@facet_filter.get_filter_query.and(type_query_builder)).build.to_json
+    @criteria['aq'] = advanced_query_builder.build.to_json
+    @criteria['filter'] = @facet_filter.get_filter_query.and(type_query_builder).build.to_json
     @criteria['facet[]'] = @facet_filter.get_facet_types
     @criteria['page_size'] = params.fetch(:page_size, AppConfig[:search_results_page_size])
   end


### PR DESCRIPTION
Hi @bobbi-SMR,

I awoke with that terrible feeling I'd done something wrong.. and sure enough I had! In `set_up_advanced_search` I think I messed up the ampersands when building the base_search string.. but more importantly I misused  the 'filter' param.  The ArchivesSpace backend search API actually supports a parameter purely for advanced queries (for a similar multiline search in the staff interface and old public app) - `aq`.

The patch below moves the advanced query to use this parameter, leaving the `filter` parameter to focus on facet filtering.  Sorry! Hopefully it's useful!

It's a worry when you start dreaming about code and bugs 💤 😨  Less cheese before bed might help I suppose.

Thanks and happy weekend,
Payten