### PR TITLE
Repository scoping for subjects and agents

### DIFF
--- a/app/archivesspace-public/app/controllers/repositories_controller.rb
+++ b/app/archivesspace-public/app/controllers/repositories_controller.rb
@@ -53,10 +53,9 @@ class RepositoriesController < ApplicationController
     repo_id = params.require(:rid)
     @base_search = "/repositories/#{repo_id}/search?"
     begin
-      # this is temporary unless & until the search respositories endpoint is fixed on the backend
       new_search_opts =  DEFAULT_REPO_SEARCH_OPTS 
-      new_search_opts['fq'] = ["repository:\"/repositories/#{repo_id}\""]
-     
+      new_search_opts['repo_id'] = repo_id
+
       set_up_advanced_search(DEFAULT_TYPES, DEFAULT_SEARCH_FACET_TYPES, new_search_opts, params)
 #NOTE the redirect back here on error!
     rescue Exception => error

--- a/app/archivesspace-public/app/lib/advanced_query_builder.rb
+++ b/app/archivesspace-public/app/lib/advanced_query_builder.rb
@@ -140,7 +140,7 @@ class AdvancedQueryBuilder
                                  'jsonmodel_type' => 'field_query'
                                })
 
-      if query_data["type"] == "enum"
+      if ['enum', 'uri'].include?(query_data["type"])
         query['literal'] = true
       end
 


### PR DESCRIPTION
When we're searching within the context of a repository, we don't want
to show subjects or agents unless they're linked within the repository
of interest.  Add a filter to ensure that.