### PR TITLE
Don't loop if there aren't any search results

### DIFF
--- a/app/archivesspace-public/app/services/archives_space_client.rb
+++ b/app/archivesspace-public/app/services/archives_space_client.rb
@@ -148,7 +148,7 @@ class ArchivesSpaceClient
 
       results.concat(hits['results'])
 
-      if hits['last_page'] == page
+      if hits['last_page'] == page || hits['last_page'] == 0
         break
       else
         page += 1


### PR DESCRIPTION
Just a little bug fix (that was my fault in the first place).  Starting up the app when there aren't any repositories yet causes it to get stuck in a loop :)