### PR TITLE
AR-1481 Add basic representation of related_accessions and related_resources

### DIFF
--- a/app/archivesspace-public/app/controllers/accessions_controller.rb
+++ b/app/archivesspace-public/app/controllers/accessions_controller.rb
@@ -71,7 +71,7 @@ class AccessionsController <  ApplicationController
   def show
     uri = "/repositories/#{params[:rid]}/accessions/#{params[:id]}"
     @criteria = {}
-    @criteria['resolve[]']  = ['repository:id', 'resource:id@compact_resource']
+    @criteria['resolve[]']  = ['repository:id', 'resource:id@compact_resource', 'related_resource_uris:id']
     @results =  archivesspace.search_records([uri],1,@criteria)
     @results =  handle_results(@results)
     if !@results['results'].blank? && @results['results'].length > 0
@@ -83,6 +83,7 @@ class AccessionsController <  ApplicationController
       @context.push({:uri => '', :crumb => @result['json']['title'] })
       @subjects = process_subjects(@result['json']['subjects'])
       @agents = process_agents(@result['json']['linked_agents'], @subjects)
+      @related_resources = process_related_resources(@result)
       process_extents(@result['json'])
     else
       @type = I18n.t('accession._singular')
@@ -91,5 +92,15 @@ class AccessionsController <  ApplicationController
       @back_url = request.referer || ''
       render  'shared/not_found'
     end
+  end
+
+  private
+
+  def process_related_resources(result)
+    result['related_resource_uris'].collect{|uri|
+      result['_resolved_related_resource_uris'][uri].first
+    }.select{|resource|
+      resource['publish']
+    }
   end
 end

--- a/app/archivesspace-public/app/views/accessions/_related_resources.html.erb
+++ b/app/archivesspace-public/app/views/accessions/_related_resources.html.erb
@@ -1,0 +1,7 @@
+<ul>
+<% resources.each do |resource| %>
+  <li>
+    <%= link_to resource['title'], resource['uri'] %>
+  </li>
+<% end %>
+</ul>

--- a/app/archivesspace-public/app/views/accessions/show.html.erb
+++ b/app/archivesspace-public/app/views/accessions/show.html.erb
@@ -8,7 +8,7 @@
 
   <br/>
   <%= render partial: 'shared/record', locals: {:rec => @result['json']} %>
-
+  <%= render partial: 'shared/record_innards' %>
   </div>
 <!-- <%= @result.pretty_inspect.html_safe %> -->
     <%# nothing at the moment %>

--- a/app/archivesspace-public/app/views/resources/_related_accessions.html.erb
+++ b/app/archivesspace-public/app/views/resources/_related_accessions.html.erb
@@ -1,0 +1,17 @@
+<h4><%= t('resource._public.related_accessions.accessions') %></h4>
+<ul>
+<% accessions.each do |accession| %>
+  <li>
+    <%= link_to accession['title'], accession['uri'] %>
+  </li>
+<% end %>
+</ul>
+
+<% unless deaccessions.empty? %>
+<h4><%= t('resource._public.related_accessions.deaccessions') %></h4>
+<ul>
+<% deaccessions.each do |deaccession| %>
+  <li><%= deaccession['description'] %></li>
+<% end %>
+</ul>
+<% end %>

--- a/app/archivesspace-public/app/views/shared/_record_innards.html.erb
+++ b/app/archivesspace-public/app/views/shared/_record_innards.html.erb
@@ -68,6 +68,14 @@
 	    <%= render partial: 'shared/accordion_panel', locals: {:p_title =>  t('repository.details'), 
 	    :p_id => 'repo_deets', :p_body => x} %>
         <% end %>
+        <% unless @related_accessions.blank? %>
+          <% x = render partial: 'resources/related_accessions', locals: {:accessions => @related_accessions, :deaccessions => @related_accession_deaccessions} %>
+          <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('related_accessions'), :p_id => 'related_accessions_list', :p_body => x} %>
+        <% end %>
+        <% unless @related_resources.blank? %>
+          <% x = render partial: 'accessions/related_resources', locals: {:resources => @related_resources} %>
+          <%= render partial: 'shared/accordion_panel', locals: {:p_title => t('related_resources'), :p_id => 'related_resources_list', :p_body => x} %>
+        <% end %>
       </div>        
     </div>
     <script type="text/javascript" >initialize_accordion(".note_panel", "<%= t('accordion.expand') %>" , "<%= t('accordion.collapse') %>");

--- a/app/archivesspace-public/config/locales/en.yml
+++ b/app/archivesspace-public/config/locales/en.yml
@@ -265,6 +265,8 @@ en:
   cont_arr: Collection organization
   accessed: Accessed
   containers: Container List
+  related_accessions: Related Accessions
+  related_resources: Related Resources
 
   accession:
    _singular: Unprocessed 
@@ -272,6 +274,9 @@ en:
    _public:
       section:
         summary: Summary
+      related_accessions:
+        accessions: Accession Records
+        deaccessions: Deaccession Records
 
   archival_object:
     _singular: Archival Record
@@ -339,6 +344,9 @@ en:
         series_statement: Series statement
         note: Note
         revision: Revision Statements
+      related_accessions:
+        accessions: Accession Records
+        deaccessions: Deaccession Records
 
   related_resource:
     _singular: Related Collection


### PR DESCRIPTION
This delivers AR-1481 by indexing some more stuff and adding some new templates to show these relationships - the templates are quite simple and will need to be fleshed out with data from the objects.. but it's a start.